### PR TITLE
Fix user registration via HTML

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -3,11 +3,6 @@ from rest_framework import generics
 from .serializers import RegisterSerializer
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
-from django.contrib import messages
-from django.http import HttpResponse
-import requests
-
-
 
 def home_view(request):
     return render(request,'home.html')
@@ -43,31 +38,24 @@ def register_view(request):
         # Validar que las contraseñas coincidan
         if password != confirm:
             error = "Las contraseñas no coinciden."
-            return render(request, "accounts/register.html", {
-                "error": error,
-                "mensaje": mensaje
-            })
-
-        # Enviar datos al endpoint de registro
-        response = requests.post(
-            "http://127.0.0.1:8000/api/auth/register/",
-            json={
+        else:
+            serializer = RegisterSerializer(data={
                 "username": username,
                 "email": email,
-                "password": password
-            }
-        )
-
-        if response.status_code == 201:
-            mensaje = "¡Usuario registrado correctamente!"
-        else:
-            error_data = response.json()
-            error = (
-                error_data.get("username") or
-                error_data.get("email") or
-                error_data.get("password") or
-                "Error al registrar."
-            )
+                "password": password,
+            })
+            if serializer.is_valid():
+                serializer.save()
+                mensaje = "¡Usuario registrado correctamente!"
+            else:
+                # Obtener el primer mensaje de error disponible
+                errores = serializer.errors
+                error = (
+                    errores.get("username") or
+                    errores.get("email") or
+                    errores.get("password") or
+                    "Error al registrar."
+                )
 
     return render(request, "accounts/register.html", {"mensaje": mensaje, "error": error})
 def logout_view(request):


### PR DESCRIPTION
## Summary
- remove unnecessary `requests` call in `register_view`
- register user directly using serializer

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684daff8b4bc8330b07f68663d5ebbbc